### PR TITLE
fix: prevent footer from overlapping sidebar nav on desktop

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,10 +13,10 @@
     .wrapper {
       display: grid;
       grid-template-columns: 300px 1fr;
-      grid-template-rows: 1fr auto;
       grid-template-areas:
         "sidebar content"
         "footer  footer";
+      align-content: space-between;
       min-height: 100vh;
       width: 90%;
       max-width: 1400px;


### PR DESCRIPTION
fix: prevent footer from overlapping sidebar nav on desktop